### PR TITLE
Fix mobile viewport scaling and enable pinch-zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Create beautiful spirograph patterns with interactive gears, rings, and customizable pens. Mobile-friendly generative art tool." />
     <meta name="theme-color" content="#ff8c40" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/styles.css
+++ b/styles.css
@@ -39,7 +39,7 @@ body{
 
 .layout{position:fixed; inset:0; width:100%; height:100%}
 .canvas-wrap{position:absolute; top:0; left:0; width:100%; height:100%; overflow:hidden}
-canvas{position:absolute; top:0; left:0; width:100%; height:100%; touch-action:none}
+canvas{position:absolute; top:0; left:0; width:100%; height:100%; touch-action:pinch-zoom}
 #overlay{position:absolute; inset:0; width:100%; height:100%; pointer-events:none}
 .hint{position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); color:var(--muted); background:#0c1434aa; border:1px solid #22325f; padding:8px 12px; border-radius:10px; pointer-events:none}
 


### PR DESCRIPTION
## Summary
- Allow mobile browsers to scale the canvas by removing the `user-scalable=no` restriction and enabling safe area coverage.
- Permit pinch-zoom gestures on the drawing canvas for better mobile usability.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d7459cfc832c8edb375e934c569b